### PR TITLE
Standardised go package names to integrate with go-tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ To install the binary directly:
 #### Build from scratch
 To build the executable from scratch:
 1. Install the most recent version of `go` language on your system
-2. `git clone git@github.com:DrakeW/corgi.git`
-3. Run `go build -o corgi` inside of the repo
-4. `ln -s $(pwd)/corgi <your bin folder>/corgi`
+2. `go get github.com/DrakeW/corgi`
+3. `go install github.com/DrakeW/corgi`
 
 ### Install a fuzzy-finder
 `corgi` will enable interactive selection if you install a fuzzy finder, the currently supported two are [fzf](https://github.com/junegunn/fzf) and [peco](https://github.com/peco/peco).

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"corgi/util"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/DrakeW/corgi/util"
+	"github.com/spf13/cobra"
 )
 
 var editCmd = &cobra.Command{

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"corgi/snippet"
+	"github.com/DrakeW/corgi/snippet"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"corgi/snippet"
+	"github.com/DrakeW/corgi/snippet"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"bytes"
-	"corgi/config"
-	"corgi/snippet"
-	"corgi/util"
 	"errors"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/DrakeW/corgi/config"
+	"github.com/DrakeW/corgi/snippet"
+	"github.com/DrakeW/corgi/util"
 	"github.com/fatih/color"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"corgi/util"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/DrakeW/corgi/util"
 )
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "corgi/cmd"
+import "github.com/DrakeW/corgi/cmd"
 
 func main() {
 	cmd.Execute()

--- a/snippet/snippet.go
+++ b/snippet/snippet.go
@@ -1,14 +1,15 @@
 package snippet
 
 import (
-	"corgi/util"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
 	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/DrakeW/corgi/util"
+	"github.com/fatih/color"
 )
 
 type Snippet struct {

--- a/snippet/snippets.go
+++ b/snippet/snippets.go
@@ -1,15 +1,16 @@
 package snippet
 
 import (
-	"corgi/util"
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
 	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
 	"time"
+
+	"github.com/DrakeW/corgi/util"
+	"github.com/fatih/color"
 )
 
 type SnippetsMeta struct {

--- a/snippet/step.go
+++ b/snippet/step.go
@@ -1,18 +1,19 @@
 package snippet
 
 import (
-	"corgi/util"
 	"fmt"
-	"github.com/fatih/color"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/DrakeW/corgi/util"
+	"github.com/fatih/color"
 )
 
 type StepInfo struct {
-	Command           string `json:"command"`
-	Description       string `json:"description,omitempty"`
+	Command     string `json:"command"`
+	Description string `json:"description,omitempty"`
 }
 
 var TemplateParamsRegex = `<([^(<>|\s)]+)>`


### PR DESCRIPTION
Pull package imports into host/project/package so that the project can be pulled using `go get github.com/DrakeW/corgi` and installed with `go install github.com/DrakeW/corgi`

Reflect these changes in the README
